### PR TITLE
[IRONWOOD-258] Remove intro feedback message after do_attempt

### DIFF
--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1808,7 +1808,8 @@ function DragAndDropBlock(runtime, element, configuration) {
             state.attempts = data.attempts;
             state.grade = data.grade;
             state.feedback = data.feedback;
-            state.overall_feedback = data.overall_feedback;
+            const filtered = data.overall_feedback.filter(el => el.message_class !== null)
+            state.overall_feedback = filtered;
             state.last_action_correct = data.correct;
 
             if (attemptsRemain()) {


### PR DESCRIPTION
**Description:**
* Add filtering for overall_feedback messages on do_attempt action, to remove intro message (used only for assessment mode)

**YouTrack:**
https://youtrack.raccoongang.com/issue/IRONWOOD-258

- [x] Demo is shown to QA

